### PR TITLE
Bug 1438836 - add an SPF record for artifacts domain

### DIFF
--- a/modules/artifacts-domain/zone.tf
+++ b/modules/artifacts-domain/zone.tf
@@ -15,6 +15,16 @@ resource "aws_route53_record" "artifacts-domain-ns" {
     ]
 }
 
+resource "aws_route53_record" "artifacts-domain-spf" {
+    zone_id = "${aws_route53_zone.artifacts-domain.zone_id}"
+    name = "${var.domain}"
+    type = "TXT"
+    ttl = "30"
+    records = [
+        "v=spf1 -all",
+    ]
+}
+
 resource "aws_route53_record" "artifacts-domain-alias" {
     zone_id = "${aws_route53_zone.artifacts-domain.zone_id}"
     name = "${var.domain}"


### PR DESCRIPTION
```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  + module.artifacts_domain.aws_route53_record.artifacts-domain-spf
      id:                 <computed>
      fqdn:               <computed>
      name:               "taskcluster-artifacts.net"
      records.#:          "1"
      records.4125299627: "v=spf1 -all"
      ttl:                "30"
      type:               "TXT"
      zone_id:            "Z34G0DY7X0PABI"


Plan: 1 to add, 0 to change, 0 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.

```