### PR TITLE
Upgraded tc-worker

### DIFF
--- a/modules/static-service/service.tf
+++ b/modules/static-service/service.tf
@@ -1,9 +1,12 @@
 data "aws_ami" "coreos" {
-  most_recent = true
-
   filter {
-    name   = "name"
-    values = ["CoreOS-stable-*"]
+    // Always be specific enough to only get single AMI.
+    // Feel free to update the version number, by searching in AWS console
+    // and finding a more recent one. Using most_recent = true, causes changes
+    // when coreos updates their AMIs, and breaks our ability to rollback.
+    name = "name"
+
+    values = ["CoreOS-stable-1688.5.3-*"]
   }
 
   filter {

--- a/modules/tc-worker-docker-packet/machines.tf
+++ b/modules/tc-worker-docker-packet/machines.tf
@@ -93,7 +93,7 @@ config:
   webHookServer:
     provider:       webhooktunnel
   worker:
-    concurrency:          1
+    concurrency:          ${var.concurrency}
     minimumReclaimDelay:  30
     pollingInterval:      5
     reclaimOffset:        300

--- a/modules/tc-worker-docker-packet/variables.tf
+++ b/modules/tc-worker-docker-packet/variables.tf
@@ -10,6 +10,12 @@ variable "packet_instance_type" {
   default     = "baremetal_0"
 }
 
+variable "concurrency" {
+  type        = "string"
+  description = "number of concurrent tasks to run on each worker machine"
+  default     = "1"
+}
+
 variable "log_host" {
   type        = "string"
   description = "hostname that log should be sent to, see also log_port"

--- a/modules/tc-worker-docker-packet/variables.tf
+++ b/modules/tc-worker-docker-packet/variables.tf
@@ -23,13 +23,13 @@ variable "log_port" {
 variable "taskcluster_worker_version" {
   type        = "string"
   description = "version of taskcluster-worker to install"
-  default     = "0.1.16"
+  default     = "0.1.17"
 }
 
 variable "taskcluster_worker_hash" {
   type        = "string"
-  description = "accessToken to pass to the worker"
-  default     = "sha512-3469e02c92b3bb4b7f1d81115a060a41a07f66989b5297d0c06f410095f79c3dd30b3d78f7b2f44db6bb654a786d467da8b71fbfac644214f828c7b4b956aa6b"
+  description = "hash of the binary, curl -L <url> | sha512sum -"
+  default     = "sha512-c93ff9a366d388e5d5a19818ef94b859528ec549bcdd478ddcc6eb8bae642bda76c987a34f92aa6ee13e222684fda5ab979621e845c4a5eaa5f5ada0475e1565"
 }
 
 variable "taskcluster_client_id" {

--- a/tc-worker-docker-v1.tf
+++ b/tc-worker-docker-v1.tf
@@ -12,3 +12,67 @@ module "tc-worker-docker-v1" {
   project                  = "tc-worker-docker-v1"
   packet_project_id        = "d701a359-ae99-43ec-868b-6dd551336b1e"
 }
+
+module "tc-worker-docker-v1-A1" {
+  source                   = "modules/tc-worker-docker-packet"
+  number_of_machines       = "1"
+  log_host                 = "${var.tc_worker_log_host}"
+  log_port                 = "${var.tc_worker_log_port}"
+  taskcluster_client_id    = "project/taskcluster/taskcluster-worker/terraform-packet/tc-worker-docker-v1"
+  taskcluster_access_token = "${var.tc_worker_docker_access_token}"
+  provisioner_id           = "terraform-packet"
+  worker_type              = "tc-worker-docker-v1-A1"
+  concurrency              = "1"
+  packet_instance_type     = "t1.small.x86"
+  facility                 = "sjc1"
+  project                  = "tc-worker-docker-v1"
+  packet_project_id        = "d701a359-ae99-43ec-868b-6dd551336b1e"
+}
+
+module "tc-worker-docker-v1-A4" {
+  source                   = "modules/tc-worker-docker-packet"
+  number_of_machines       = "1"
+  log_host                 = "${var.tc_worker_log_host}"
+  log_port                 = "${var.tc_worker_log_port}"
+  taskcluster_client_id    = "project/taskcluster/taskcluster-worker/terraform-packet/tc-worker-docker-v1"
+  taskcluster_access_token = "${var.tc_worker_docker_access_token}"
+  provisioner_id           = "terraform-packet"
+  worker_type              = "tc-worker-docker-v1-A4"
+  concurrency              = "4"
+  packet_instance_type     = "t1.small.x86"
+  facility                 = "sjc1"
+  project                  = "tc-worker-docker-v1"
+  packet_project_id        = "d701a359-ae99-43ec-868b-6dd551336b1e"
+}
+
+module "tc-worker-docker-v1-B1" {
+  source                   = "modules/tc-worker-docker-packet"
+  number_of_machines       = "1"
+  log_host                 = "${var.tc_worker_log_host}"
+  log_port                 = "${var.tc_worker_log_port}"
+  taskcluster_client_id    = "project/taskcluster/taskcluster-worker/terraform-packet/tc-worker-docker-v1"
+  taskcluster_access_token = "${var.tc_worker_docker_access_token}"
+  provisioner_id           = "terraform-packet"
+  worker_type              = "tc-worker-docker-v1-B1"
+  concurrency              = "1"
+  packet_instance_type     = "c1.small.x86"
+  facility                 = "sjc1"
+  project                  = "tc-worker-docker-v1"
+  packet_project_id        = "d701a359-ae99-43ec-868b-6dd551336b1e"
+}
+
+module "tc-worker-docker-v1-B4" {
+  source                   = "modules/tc-worker-docker-packet"
+  number_of_machines       = "1"
+  log_host                 = "${var.tc_worker_log_host}"
+  log_port                 = "${var.tc_worker_log_port}"
+  taskcluster_client_id    = "project/taskcluster/taskcluster-worker/terraform-packet/tc-worker-docker-v1"
+  taskcluster_access_token = "${var.tc_worker_docker_access_token}"
+  provisioner_id           = "terraform-packet"
+  worker_type              = "tc-worker-docker-v1-B4"
+  concurrency              = "4"
+  packet_instance_type     = "c1.small.x86"
+  facility                 = "sjc1"
+  project                  = "tc-worker-docker-v1"
+  packet_project_id        = "d701a359-ae99-43ec-868b-6dd551336b1e"
+}


### PR DESCRIPTION
I'm already applying this:
```
-/+ module.tc-worker-docker-v1.packet_device.workers (new resource required)
      id:                      "ef7179c5-d1f0-465a-af5d-2cc015ae8ce7" => <computed> (forces new resource)
      access_private_ipv4:     "10.88.133.129" => <computed>
      access_public_ipv4:      "147.75.89.113" => <computed>
      access_public_ipv6:      "2604:1380:1000:f400::1" => <computed>
      always_pxe:              "false" => "false"
      billing_cycle:           "hourly" => "hourly"
      created:                 "2018-05-11T11:25:22Z" => <computed>
      facility:                "sjc1" => "sjc1"
      hardware_reservation_id: "" => <computed>
      hostname:                "machine-0.tc-worker-docker-v1" => "machine-0.tc-worker-docker-v1"
      locked:                  "false" => <computed>
      network.#:               "3" => <computed>
      operating_system:        "coreos_stable" => "coreos_stable"
      plan:                    "c1.small.x86" => "c1.small.x86"
      project_id:              "d701a359-ae99-43ec-868b-6dd551336b1e" => "d701a359-ae99-43ec-868b-6dd551336b1e"
      public_ipv4_subnet_size: "31" => <computed>
      root_password:           <sensitive> => <computed> (attribute changed)
      state:                   "active" => <computed>
      updated:                 "2018-05-11T11:32:56Z" => <computed>
      user_data:               <sensitive> => <sensitive> (forces new resource)
```