### PR TITLE
Fix relengapi host name

### DIFF
--- a/modules/tc-worker-docker-packet/machines.tf
+++ b/modules/tc-worker-docker-packet/machines.tf
@@ -91,7 +91,7 @@ config:
     watchdog:       {}
     relengapi:
       token:  "${var.relengapi_token}"
-      host:   "https://api.pub.build.mozilla.org/"
+      host:   "api.pub.build.mozilla.org/"
   temporaryFolder:  /mnt/tmp
   webHookServer:
     provider:       webhooktunnel


### PR DESCRIPTION
The protocol is not part of the host name.