### PR TITLE
Increase packet.net instance limit to 50

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ./env
 ./state.tf
 .terraform/
+./logs

--- a/docker-worker.tf
+++ b/docker-worker.tf
@@ -1,6 +1,6 @@
 module "docker_worker" {
   source                   = "modules/docker-worker"
-  number_of_machines       = "40"
+  number_of_machines       = "50"
   packet_instance_type     = "c1.small.x86"
   concurrency              = "4"
   provisioner_id           = "terraform-packet"

--- a/modules/docker-worker/main.tf
+++ b/modules/docker-worker/main.tf
@@ -7,6 +7,7 @@ resource "packet_device" "docker_worker" {
   facility         = "${var.facility}"
   operating_system = "ubuntu_14_04"
   billing_cycle    = "hourly"
+  tags             = ["desired_worker_count:${var.concurrency}"]
 
   connection {
     type        = "ssh"


### PR DESCRIPTION
Tag packet.net instances with the desired # of concurrent workers at setup
Ignore logs/ dir